### PR TITLE
fix(thunderx): Fix Offline BUG

### DIFF
--- a/drivers/thunderx/driver.go
+++ b/drivers/thunderx/driver.go
@@ -318,12 +318,22 @@ func (xc *XunLeiXCommon) Rename(ctx context.Context, srcObj model.Obj, newName s
 func (xc *XunLeiXCommon) Offline(ctx context.Context, args model.OtherArgs) (interface{}, error) {
 	_, err := xc.Request(FILE_API_URL, http.MethodPost, func(r *resty.Request) {
 		r.SetContext(ctx)
+		r.SetHeaders(map[string]string{
+			"X-Device-Id": xc.DeviceID,
+			"User-Agent":  xc.UserAgent,
+			"Peer-Id":     xc.DeviceID,
+			"client_id":   xc.ClientID,
+			"x-client-id": xc.ClientID,
+			"X-Guid":      xc.DeviceID,
+		})
 		r.SetBody(&base.Json{
 			"kind":        "drive#file",
 			"name":        "",
 			"upload_type": "UPLOAD_TYPE_URL",
 			"url": &base.Json{
-				"url": args.Data,
+				"url":       args.Data,
+				"params":    "{}",
+				"parent_id": args.Obj.GetID(),
 			},
 		})
 	}, nil)

--- a/drivers/thunderx/driver.go
+++ b/drivers/thunderx/driver.go
@@ -325,7 +325,6 @@ func (xc *XunLeiXCommon) Offline(ctx context.Context, args model.OtherArgs) (int
 			"url": &base.Json{
 				"url": args.Data,
 			},
-			"folder_type": "DOWNLOAD",
 		})
 	}, nil)
 	if err != nil {
@@ -535,6 +534,7 @@ func (xc *XunLeiXCommon) Login(username, password string) (*TokenResp, error) {
 	if err != nil {
 		return nil, err
 	}
+	resp.UserID = resp.Sub
 	return &resp, nil
 }
 


### PR DESCRIPTION
修复了离线下载接口

---

经过排查，之前出现`captcha_invalid`报错是因为`Login`函数中未能获取到`UserID`，导致无法刷新获取到正确的`CaptchaToken`，现在问题已经修复

---

新的问题：
- 离线下载可以正确提交，但是文件保存的目录始终在根目录，即使向`迅雷X`后台接口传递`文件夹ID`，也无效。目前推测是`迅雷X`后台的限制。
- 文件上传可以正确提交和上传，也可以获取到文件相关信息，比如下载链接等，但是在网盘中不显示，目前推测是`迅雷X`后台的问题，即上传到`迅雷X`服务器后，并未关联到用户文件夹。

---

后续希望对离线下载选择器的`Storage`进行优化，设置一个统一配置项，仅用户打开指定类型的云盘时显示其选项